### PR TITLE
create extensions.json file

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,9 @@
     "naumovs.color-highlight", // Color Highlight
     "formulahendry.auto-rename-tag", // Auto Rename Tag
     "formulahendry.auto-close-tag", // Auto Close Tag
-    "eamodio.gitlens" // Gitlens
+    "editorconfig.editorconfig", // Editor Config
+    "zignd.html-css-class-completion", // IntelliSense for CSS class names in HTML
+    "mrmlnc.vscode-scss", // SCSS IntelliSense
+    "christian-kohler.path-intellisense" // Path IntelliSense
   ]
 }


### PR DESCRIPTION
Gerekli Extensionları vs açıldığın da otomatik yüklemesi gerektiğinin bildirimini verir ve seçilirse yükler.

Extensionların sıralaması.

(Kesinlikle kullandığımız extensionslar)
-- Name That Colors
-- Prettier
-- Stylelint
-- Eslint
-- Sass
-- Twig Language (Bunu eklersek vscode settingsine bir ayar eklememiz gerekmekte çünkü twig dosyalarını eklenti düzeltemiyor.)

Ekstra Hepimizin genelde kullandığı extensionlar
-- Color Highlight
-- Auto Rename Tag
-- Auto Close Tag
-- Git Lens

Bunları ekleme sebebim çoğunluğumuz zaten kullanıyoruz. Buraya ekledimki tekrardan her birini yüklemek zorunda kalmayalım.

Aklıma gelen temel extensionlar bunlar. Üzerine aklınıza gelirse ekleyelim.