### PR TITLE
Fixed the problem that gulp not watch the images if the folder name contains `icons` word

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -197,7 +197,7 @@ gulp.task('serve', () => {
   );
 
   gulp.watch(
-    [`${configs.paths.src}/img/**/*`, `!${configs.paths.src}/img/{icons,icons/**}`],
+    [`${configs.paths.src}/img/**/*`, `!${configs.paths.src}/img/icons/**`],
     gulp.series('sync:build-image', 'sync:deploy-images', 'reload'),
   );
 });


### PR DESCRIPTION
Closes #154